### PR TITLE
Fix: Prevent seeder script from causing premature server exit

### DIFF
--- a/backend/utils/seeder.js
+++ b/backend/utils/seeder.js
@@ -241,13 +241,17 @@ const deleteData = async () => {
 };
 
 // Run import or delete
-if (process.argv[2] === "-i") {
-  importData();
-} else if (process.argv[2] === "-d") {
-  deleteData();
-} else {
-  console.log(
-    "ℹ️ Use `node utils/seeder.js -i` to import data or `-d` to delete data"
-  );
-  process.exit();
+if (require.main === module) {
+  if (process.argv[2] === "-i") {
+    importData();
+  } else if (process.argv[2] === "-d") {
+    deleteData();
+  } else {
+    console.log(
+      "ℹ️ Use `node utils/seeder.js -i` to import data or `-d` to delete data"
+    );
+    process.exit();
+  }
 }
+
+module.exports = { rooms, importData, deleteData };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
The `backend/utils/seeder.js` script contained logic to parse command-line arguments and call `process.exit()`. This logic was being executed when `server.js` (via `databaseInit.js`) imported `seeder.js`, causing the server to terminate immediately after starting, leading to a "clean exit" with nodemon.

This commit wraps the command-line specific logic in `seeder.js` within an `if (require.main === module)` block. This ensures that the argument parsing and `process.exit()` calls only occur when `seeder.js` is run directly as a script, and not when it is imported by other modules.

The `rooms` array, `importData` and `deleteData` functions are now explicitly exported from `seeder.js` to ensure they remain available for use by `databaseInit.js` and for direct script execution.